### PR TITLE
Feature(#17): add amount service and query

### DIFF
--- a/packages/bbclient/src/app/page.tsx
+++ b/packages/bbclient/src/app/page.tsx
@@ -1,8 +1,23 @@
+"use client";
+
 import styles from "./styles/home.module.scss";
 import Link from "next/link";
 import { Button, Card } from "@/components";
+import { useQuery } from "@apollo/client";
+import { GET_AMOUNT_SUMMARY } from "../graphql/queries/Account";
+import { useEffect } from "react";
 
 export default function Home() {
+  const { data, loading, error, refetch } = useQuery(GET_AMOUNT_SUMMARY, {
+    variables: {
+      input: {},
+    },
+  });
+
+  useEffect(() => {
+    console.log({ data });
+  }, [data]);
+
   return (
     <div className={styles.container}>
       {/* 거래내역 페이지 이동 */}

--- a/packages/bbclient/src/app/page.tsx
+++ b/packages/bbclient/src/app/page.tsx
@@ -5,9 +5,10 @@ import Link from "next/link";
 import { Button, Card } from "@/components";
 import { useQuery } from "@apollo/client";
 import { GET_AMOUNT_SUMMARY } from "../graphql/queries/Account";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  const [summary, setSummary] = useState<any>();
   const { data, loading, error, refetch } = useQuery(GET_AMOUNT_SUMMARY, {
     variables: {
       input: {},
@@ -15,7 +16,10 @@ export default function Home() {
   });
 
   useEffect(() => {
-    console.log({ data });
+    if (!data?.getAmountSummary) return;
+
+    const sm = data.getAmountSummary;
+    setSummary(sm);
   }, [data]);
 
   return (
@@ -30,28 +34,28 @@ export default function Home() {
       {/* 총 금액 */}
       <section>
         <Card>
-          <span>{"Total amount"}</span>
+          <span>{`Total amount ${summary?.totalBalance}`}</span>
         </Card>
       </section>
 
       {/* 저축 금액 */}
       <section>
         <Card>
-          <span>{"Saving amount"}</span>
+          <span>{`Saving amount ${summary?.savingBalance}`}</span>
         </Card>
       </section>
 
       {/* 바로 출금 가능 금액 */}
       <section>
         <Card>
-          <span>{"Available amount"}</span>
+          <span>{`Available amount ${summary?.availableBalance}`}</span>
         </Card>
       </section>
 
       {/* 출금 예정 금액  */}
       <section>
         <Card>
-          <span>{"Available amount"}</span>
+          <span>{`Holding amount ${summary?.holdBalance}`}</span>
         </Card>
       </section>
     </div>

--- a/packages/bbclient/src/components/Transaction/TransactionForm.tsx
+++ b/packages/bbclient/src/components/Transaction/TransactionForm.tsx
@@ -134,7 +134,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
           </div>
         ) : selected === "INCOME" ? (
           <Form.Item label="수령 계좌" name="accountId">
-            <Select name="toAccountId" value={init?.toAccountId}>
+            <Select name="accountId" value={init?.toAccountId}>
               {ACCOUNTS.map(({ value, label }) => (
                 <Select.Option key={value} value={value}>
                   {label}

--- a/packages/bbclient/src/graphql/queries/Account/getAmountSummary.ts
+++ b/packages/bbclient/src/graphql/queries/Account/getAmountSummary.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const GET_AMOUNT_SUMMARY = gql`
+  query GetAmountSummary($input: GetAmountSummaryInput!) {
+    getAmountSummary(input: $input) {
+      availableBalance
+      fixedDepositBalance
+      holdBalance
+      investmentBalance
+      savingBalance
+      totalBalance
+    }
+  }
+`;

--- a/packages/bbclient/src/graphql/queries/Account/index.ts
+++ b/packages/bbclient/src/graphql/queries/Account/index.ts
@@ -1,0 +1,3 @@
+import { GET_AMOUNT_SUMMARY } from "./getAmountSummary";
+
+export { GET_AMOUNT_SUMMARY };

--- a/packages/bbserver/src/Account/account.resolver.ts
+++ b/packages/bbserver/src/Account/account.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { AccountService } from "./account.service";
+import { GetAmountSummaryInput, GetAmountSummaryOutput } from './dto/get-amount-summary.dto';
 import {
   CreateAccountInput,
   CreateAccountOutput,
@@ -54,5 +55,15 @@ export class AccountResolver {
   @Query(() => GetAccountListOutput)
   async getAccountList(@Args("input", { nullable: true }) input?: GetAccountListInput): Promise<GetAccountListOutput> {
     return this.accountService.getAccountList();
+  }
+
+  /**
+   * Resolver - 자산 현황 조회
+   * @param GetAmountSummaryInput
+   * @return GetAmountSummaryOutput
+   */
+  @Query(() => GetAmountSummaryOutput)
+  async getAmountSummary(@Args("input", { nullable: true }) input?: GetAmountSummaryInput): Promise<GetAmountSummaryOutput> {
+    return this.accountService.getAmountSummary();
   }
 }

--- a/packages/bbserver/src/Account/account.service.ts
+++ b/packages/bbserver/src/Account/account.service.ts
@@ -11,6 +11,7 @@ import {
 } from "./dto";
 import { PrismaService } from "../Prisma/prisma.service";
 import { Prisma } from "@prisma/client";
+import { GetAmountSummaryInput, GetAmountSummaryOutput } from './dto/get-amount-summary.dto';
 
 @Injectable()
 export class AccountService {
@@ -93,5 +94,33 @@ export class AccountService {
     }
 
     return { accounts: sanitizedAccounts };
+  }
+
+  /**
+   * 자산 현황 조회
+   */
+  async getAmountSummary(input?: GetAmountSummaryInput): Promise<GetAmountSummaryOutput> {
+    const accounts = await this.prisma.account.findMany();
+
+    let total = 0;
+    let available = 0;
+    let saving = 0;
+    let hold = 0;
+
+    accounts.map((account) => ({
+      // fixedDepositBalance: account.fixedDepositBalance.toNumber(),
+      // investmentBalance: account.investmentBalance.toNumber(),
+      total: total += account.totalBalance.toNumber(),
+      available: available += account.availableBalance.toNumber(),
+      saving: saving += account.savingBalance.toNumber(),
+      hold: hold += account.holdBalance.toNumber(),
+    }));
+    
+    return {
+      totalBalance: total,
+      availableBalance: available,
+      savingBalance: saving,
+      holdBalance: hold
+    }
   }
 }

--- a/packages/bbserver/src/Account/account.service.ts
+++ b/packages/bbserver/src/Account/account.service.ts
@@ -106,21 +106,25 @@ export class AccountService {
     let available = 0;
     let saving = 0;
     let hold = 0;
+    let fix = 0;
+    let invest = 0;
 
     accounts.map((account) => ({
-      // fixedDepositBalance: account.fixedDepositBalance.toNumber(),
-      // investmentBalance: account.investmentBalance.toNumber(),
       total: total += account.totalBalance.toNumber(),
       available: available += account.availableBalance.toNumber(),
       saving: saving += account.savingBalance.toNumber(),
       hold: hold += account.holdBalance.toNumber(),
+      fix: fix += account.fixedDepositBalance.toNumber(),
+      invest: invest += account.investmentBalance.toNumber(),
     }));
     
     return {
       totalBalance: total,
       availableBalance: available,
       savingBalance: saving,
-      holdBalance: hold
+      holdBalance: hold,
+      fixedDepositBalance: fix,
+      investmentBalance: invest,
     }
   }
 }

--- a/packages/bbserver/src/Account/dto/get-amount-summary.dto.ts
+++ b/packages/bbserver/src/Account/dto/get-amount-summary.dto.ts
@@ -1,0 +1,29 @@
+import { Field, InputType, ObjectType } from "@nestjs/graphql";
+import { BaseOutput } from "src/common";
+
+@InputType()
+export class GetAmountSummaryInput {
+    @Field(() => Boolean, { nullable: true, description: '더미 필드 (사용되지 않음)' })
+    _?: boolean;
+}
+
+@ObjectType()
+export class GetAmountSummaryOutput extends BaseOutput {
+    @Field(() => Number, { description: "계좌 총 금액 (자산)", defaultValue: 0 })
+    totalBalance?: number;
+  
+    @Field(() => Number, { description: "실제 입출금 가능한 금액", defaultValue: 0 })
+    availableBalance?: number;
+  
+    @Field(() => Number, { description: "적금에 묶여 있는 금액", defaultValue: 0 })
+    savingBalance?: number;
+  
+    @Field(() => Number, { description: "예금에 묶여 있는 금액", defaultValue: 0 })
+    fixedDepositBalance?: number;
+  
+    @Field(() => Number, { description: "투자 금액 (예: CMA, 펀드 등)", defaultValue: 0 })
+    investmentBalance?: number;
+  
+    @Field(() => Number, { description: "출금 예약 및 결제 대기 중인 금액", defaultValue: 0 })
+    holdBalance?: number;
+}

--- a/packages/bbserver/src/Account/dto/index.ts
+++ b/packages/bbserver/src/Account/dto/index.ts
@@ -2,12 +2,15 @@ import { GetAccountInput, GetAccountOutput } from "./get-account.dto";
 import { GetAccountListInput, GetAccountListOutput } from "./get-account-list.dto";
 import { CreateAccountInput, CreateAccountOutput } from "./create-account.dto";
 import { UpdateAccountInput, UpdateAccountOutput } from "./update-account.dto";
+import { GetAmountSummaryInput, GetAmountSummaryOutput } from './get-amount-summary.dto';
 
 export {
   GetAccountInput,
   GetAccountOutput,
   GetAccountListInput,
   GetAccountListOutput,
+  GetAmountSummaryInput,
+  GetAmountSummaryOutput,
   CreateAccountInput,
   CreateAccountOutput,
   UpdateAccountInput,

--- a/packages/bbserver/src/schema.gql
+++ b/packages/bbserver/src/schema.gql
@@ -109,6 +109,32 @@ type GetAccountOutput {
   message: ErrorOutput
 }
 
+input GetAmountSummaryInput {
+  """더미 필드 (사용되지 않음)"""
+  _: Boolean
+}
+
+type GetAmountSummaryOutput {
+  """실제 입출금 가능한 금액"""
+  availableBalance: Float!
+
+  """예금에 묶여 있는 금액"""
+  fixedDepositBalance: Float!
+
+  """출금 예약 및 결제 대기 중인 금액"""
+  holdBalance: Float!
+
+  """투자 금액 (예: CMA, 펀드 등)"""
+  investmentBalance: Float!
+  message: ErrorOutput
+
+  """적금에 묶여 있는 금액"""
+  savingBalance: Float!
+
+  """계좌 총 금액 (자산)"""
+  totalBalance: Float!
+}
+
 input GetTransactionInput {
   id: Float!
 }
@@ -144,6 +170,7 @@ type Mutation {
 type Query {
   getAccount(input: GetAccountInput!): GetAccountOutput!
   getAccountList(input: GetAccountListInput): GetAccountListOutput!
+  getAmountSummary(input: GetAmountSummaryInput): GetAmountSummaryOutput!
   getTotalAmount: Float!
   getTransaction(input: GetTransactionInput!): GetTransactionOutput!
   getTransactionList(input: GetTransactionListInput): GetTransactionListOutput!


### PR DESCRIPTION
## 📄 Summary

> 서비스 메인 화면에서 각 자산 현황을 표시하기 위해 API 추가 및 쿼리문 작성

---

## 🔧 Describe your changes

> 어떤 변경을 했는지 상세히 기술해주세요.

- Account table의 계좌별 금액 현황을 통해 항목 별 금액 총 합을 추출 및 반환
- GET API 추가 - getAmountSummary (server)
- Query문 추가 (client)

***

## 🔗 Related Issue

Closes #17

---

## ✅ PR Checklist

### 🎯 기능 구현

- [x] 요구사항 명세서(또는 이슈)에 적힌 내용을 완전히 반영했는가?
- [x] 실제 동작이 기획/의도와 일치하는가?

### 🔍 코드 품질 및 유지보수성

- [x] 하드코딩 없이 유연한 구조로 작성되었는가?
- [x] 재사용 가능한 유틸 함수, 컴포넌트로 분리했는가?
- [x] 불필요한 `console.log`, dead code, 주석을 제거했는가?

### 🧪 안정성 및 예외 처리

- [x] 엣지 케이스 및 예외 상황을 고려했는가?
- [x] 백엔드 응답 지연/에러 상황에서도 앱이 정상 작동하는가?

### 🧱 구조 및 네이밍

- [x] 파일/컴포넌트/함수/변수명이 명확하고 일관적인가?
- [x] 컴포넌트/로직이 너무 크거나 복잡하지 않은가? (단일 책임 원칙)

---

## 📎 기타 참고사항

> 현재는 단순하게 account table의 모든 요소들을 루프 돌려서 총합을 계산하고 있는데 고정지출에 대한 프로세스가 확립되면 점차 구조가 개선될 예정이다
